### PR TITLE
fix: pre-launch fixes

### DIFF
--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -408,12 +408,12 @@ keep_most_recent_stable () {
 add_to_path () {
 
 	# Check which files exist
-	if [ $(test -f ~/.zshrc) ] && [[ "$onpath" = false ]]; then
+	if [ -f ~/.zshrc ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.zshrc..."
 		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.zshrc
 	fi
 
-	if [ $(test -f ~/.bashrc) ] && [[ "$onpath" = false ]]; then
+	if [ -f ~/.bashrc ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.bashrc..."
 		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
 	fi

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -128,7 +128,6 @@ set_variables() {
 	linux_install_dir=~/.local/share/hpcflow
 	macOS_install_dir=~/Library/Application\ Support/hpcflow
 
-	#latest_stable_releases="https://raw.githubusercontent.com/hpcflow/hpcflow-new/main/docs/source/released_binaries.yml"
 	latest_stable_releases="https://raw.githubusercontent.com/hpcflow/hpcflow-new/dummy-stable/docs/source/released_binaries.yml"
 	latest_prerelease_releases="https://raw.githubusercontent.com/hpcflow/hpcflow-new/develop/docs/source/released_binaries.yml"
 

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -416,7 +416,7 @@ add_to_path () {
 
 	if [ $(test -f ~/.bashrc) ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.bashrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashhrc
+		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
 	fi
 
 }

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -97,13 +97,13 @@ function Get-InstallDir {
 function  Get-ScriptParameters {
     $params = @{
         AppName = "matflow"
-        BaseLink = "https://github.com/matflow/matflow-new/releases/download"
+        BaseLink = "https://github.com/hpcflow/matflow-new/releases/download"
         WindowsEndingFolder ="win-dir"
 	    WindowsEndingFile = "win.exe"
         WindowsInstallDir = "${env:USERPROFILE}\AppData\Local\matflow"
 
-	    LatestStableReleases = "https://raw.githubusercontent.com/matflow/matflow-new/dummy-stable/docs/source/released_binaries.yml"
-	    LatestPrereleaseReleases="https://raw.githubusercontent.com/matflow/matflow-new/develop/docs/source/released_binaries.yml"
+	    LatestStableReleases = "https://raw.githubusercontent.com/hpcflow/matflow-new/dummy-stable/docs/source/released_binaries.yml"
+	    LatestPrereleaseReleases="https://raw.githubusercontent.com/hpcflow/matflow-new/develop/docs/source/released_binaries.yml"
 
 	    ProgressString1="Step 1 of 2: Downloading $AppName ..."
 	    ProgressString2="Step 2 of 2: Installing $AppName ..."

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -408,12 +408,12 @@ keep_most_recent_stable () {
 add_to_path () {
 
 	# Check which files exist
-	if [ $(test -f ~/.zshrc) ] && [[ "$onpath" = false ]]; then
+	if [ -f ~/.zshrc ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.zshrc..."
 		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.zshrc
 	fi
 
-	if [ $(test -f ~/.bashrc) ] && [[ "$onpath" = false ]]; then
+	if [ -f ~/.bashrc ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.bashrc..."
 		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
 	fi

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -11,6 +11,8 @@ run_main() {
 
 	set_OS_specific_variables
 
+	make_main_folder
+
 	get_artifact_names
 
 	create_install_tracker_files
@@ -278,6 +280,39 @@ get_artifact_names() {
 
 }
 
+make_main_folder() {
+	mkdir -p "${folder}"
+}
+
+create_install_tracker_files() {
+	touch "${folder}"/user_versions.txt
+	touch "${folder}"/stable_versions.txt
+}
+
+check_if_desired_version_installed() {
+
+	if [ $(grep -c "${version}-${app_name_ending}" "${folder}"/user_versions.txt) -ge 1 ] || [ $(grep -c "${version}-${app_name_ending}" "${folder}"/stable_versions.txt) -ge 1 ]; then
+
+		echo "${app_name} ${version} already installed on this system... "
+		sleep 0.2
+		echo "Exiting..."
+		exit 1
+
+	fi
+
+}
+
+check_if_symlink_folder_on_path() {
+
+	# Check if folders on path already
+	case :$PATH: in
+	*:"${folder}"/links:) onpath=true ;;
+	*) ;;
+	esac
+
+}
+
+download_artifact_to_temp() {
 create_install_tracker_files() {
 	touch "${folder}"/user_versions.txt
 	touch "${folder}"/stable_versions.txt

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -313,35 +313,6 @@ check_if_symlink_folder_on_path() {
 }
 
 download_artifact_to_temp() {
-create_install_tracker_files() {
-	touch "${folder}"/user_versions.txt
-	touch "${folder}"/stable_versions.txt
-}
-
-check_if_desired_version_installed() {
-
-	if [ $(grep -c "${version}-${app_name_ending}" "${folder}"/user_versions.txt) -ge 1 ] || [ $(grep -c "${version}-${app_name_ending}" "${folder}"/stable_versions.txt) -ge 1 ]; then
-
-		echo "${app_name} ${version} already installed on this system... "
-		sleep 0.2
-		echo "Exiting..."
-		exit 1
-
-	fi
-
-}
-
-check_if_symlink_folder_on_path() {
-
-	# Check if folders on path already
-	case :$PATH: in
-	*:"${folder}"/links:) onpath=true ;;
-	*) ;;
-	esac
-
-}
-
-download_artifact_to_temp() {
 
 	echo $progress_string_1
 	echo

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -118,7 +118,7 @@ run_main() {
 set_variables() {
 
 	app_name="matflow"
-	base_link="https://github.com/matflow/matflow-new/releases/download"
+	base_link="https://github.com/hpcflow/matflow-new/releases/download"
 
 	linux_ending_folder="linux-dir"
 	macOS_ending_folder="macOS-dir"
@@ -128,8 +128,8 @@ set_variables() {
 	linux_install_dir=~/.local/share/matflow
 	macOS_install_dir=~/Library/Application\ Support/matflow
 
-	latest_stable_releases="https://raw.githubusercontent.com/matflow/matflow-new/dummy-stable/docs/source/released_binaries.yml"
-	latest_prerelease_releases="https://raw.githubusercontent.com/matflow/matflow-new/develop/docs/source/released_binaries.yml"
+	latest_stable_releases="https://raw.githubusercontent.com/hpcflow/matflow-new/dummy-stable/docs/source/released_binaries.yml"
+	latest_prerelease_releases="https://raw.githubusercontent.com/hpcflow/matflow-new/develop/docs/source/released_binaries.yml"
 
 	progress_string_1="Step 1 of 2: Downloading ${app_name} ..."
 	progress_string_2="Step 2 of 2: Installing ${app_name} ..."

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -409,7 +409,7 @@ add_to_path () {
 
 	if [ $(test -f ~/.bashrc) ] && [[ "$onpath" = false ]]; then
 		echo "Updating ~/.bashrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashhrc
+		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
 	fi
 
 }


### PR DESCRIPTION
Various fixes:
- matflow links incorrect in ps and sh versions
- `bashhrc` typo
- test for zshrc and bashrc not working so not added to path