### PR TITLE
fix: Try return instead of exit in ps scripts

### DIFF
--- a/src/install-hpcflow.ps1
+++ b/src/install-hpcflow.ps1
@@ -34,6 +34,7 @@ function Install-HPCFlowApplication {
 		}
 		Write-Host "Installation of" $AppName "unsuccessful"
 		#Exit
+		Return
 	}
 
 	$AppName = "hpcflow"
@@ -186,6 +187,7 @@ function Check-AppInstall {
 			Write-Host "Exiting..."
 			Start-Sleep -Milliseconds 100
 			#Exit
+			Return
 		}
 	}
 	Else {
@@ -196,6 +198,7 @@ function Check-AppInstall {
 			Write-Host "Exiting..."
 			Start-Sleep -Milliseconds 100
 			#Exit
+			Return
 		}
 	}
 

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -34,6 +34,7 @@ function Install-MatFlowApplication {
 		}
 		Write-Host "Installation of" $AppName "unsuccessful"
 		#Exit
+		Return
 	}
 
 	$AppName = "matflow"
@@ -185,6 +186,7 @@ function Check-AppInstall {
 			Write-Host "Exiting..."
 			Start-Sleep -Milliseconds 100
 			#Exit
+			Return
 		}
 	}
 	Else {
@@ -195,6 +197,7 @@ function Check-AppInstall {
 			Write-Host "Exiting..."
 			Start-Sleep -Milliseconds 100
 			#Exit
+			Return
 		}
 	}
 


### PR DESCRIPTION
exit closes terminal since we're running script as script block. Return looks safer.