### PR TITLE
fix: reduce maxdepth on find

### DIFF
--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -372,7 +372,7 @@ clear_up_installed_versions () {
 	find "${folder}"/links/"${app_name}"-v* $(cat "${folder}"/stable_versions.txt 2>/dev/null) $(cat "${folder}"/user_versions.txt 2>/dev/null) $(cat "${folder}"/prerelease_versions.txt 2>/dev/null) -delete
 
 	# Remove installed apps
-	find "${folder}"/"${app_name}"-v* $(cat "${folder}"/stable_versions.txt 2>/dev/null) $(cat "${folder}"/user_versions.txt 2>/dev/null) $(cat "${folder}"/prerelease_versions.txt 2>/dev/null) -delete
+	find "${folder}"/"${app_name}"-v* -maxdepth 0 $(cat "${folder}"/stable_versions.txt 2>/dev/null) $(cat "${folder}"/user_versions.txt 2>/dev/null) $(cat "${folder}"/prerelease_versions.txt 2>/dev/null) -delete
 
 }
 


### PR DESCRIPTION
No maxdepth set on find meant that too many files were deleted when attempting to clear up previously installed versions.