### PR TITLE
Fix: pwsh prune

### DIFF
--- a/src/install-hpcflow.ps1
+++ b/src/install-hpcflow.ps1
@@ -433,13 +433,13 @@ function Create-SymLinkToApp {
 		}
 
 		if($VersionSpecFlag) {
-			Add-Content $UserVersions "$Folder\$artifact_name"
+			Add-Content $UserVersions "$artifact_name"
 		}
 		elseif($PreReleaseFlag){
-			Add-Content $PreReleaseVersions "$Folder\$artifact_name"
+			Add-Content $PreReleaseVersions "$artifact_name"
 		}
 		else{
-			Add-Content $StableVersions "$Folder\$artifact_name"
+			Add-Content $StableVersions "$artifact_name"
 		}
 
 
@@ -468,13 +468,13 @@ function Create-SymLinkToApp {
 		}
 
 		if($VersionSpecFlag) {
-			Add-Content $UserVersions "$Folder\$folder_name"
+			Add-Content $UserVersions "$folder_name"
 		}
 		elseif($PreReleaseFlag){
-			Add-Content $PreReleaseVersions "$Folder\$folder_name"
+			Add-Content $PreReleaseVersions "$folder_name"
 		}
 		else{
-			Add-Content $StableVersions "$Folder\$folder_name"
+			Add-Content $StableVersions "$folder_name"
 		}
 
 	}
@@ -509,6 +509,8 @@ function Prune-InstalledVersions {
 	$to_keep=Get-Content $ToKeepWildCard
 
 	$AppWildCard = $ScriptDataFilenames.AppName+"*"
+
+	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Write-Host
 
 	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Where-Object { $to_keep -notcontains $_.name } |`
 	Remove-Item -Recurse -whatif

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -510,7 +510,7 @@ function Prune-InstalledVersions {
 
 	$AppWildCard = $ScriptDataFilenames.AppName+"*"
 
-	Get-Content $AppWildCard | Write-Output
+	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Write-Output
 
 	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Where-Object { $to_keep -notcontains $_.name } |`
 	Remove-Item -Recurse -whatif

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -433,13 +433,13 @@ function Create-SymLinkToApp {
 		}
 
 		if($VersionSpecFlag) {
-			Add-Content $UserVersions "$Folder\$artifact_name"
+			Add-Content $UserVersions "$artifact_name"
 		}
 		elseif($PreReleaseFlag){
-			Add-Content $PreReleaseVersions "$Folder\$artifact_name"
+			Add-Content $PreReleaseVersions "$artifact_name"
 		}
 		else{
-			Add-Content $StableVersions "$Folder\$artifact_name"
+			Add-Content $StableVersions "$artifact_name"
 		}
 
 
@@ -468,13 +468,13 @@ function Create-SymLinkToApp {
 		}
 
 		if($VersionSpecFlag) {
-			Add-Content $UserVersions "$Folder\$folder_name"
+			Add-Content $UserVersions "$folder_name"
 		}
 		elseif($PreReleaseFlag){
-			Add-Content $PreReleaseVersions "$Folder\$folder_name"
+			Add-Content $PreReleaseVersions "$folder_name"
 		}
 		else{
-			Add-Content $StableVersions "$Folder\$folder_name"
+			Add-Content $StableVersions "$folder_name"
 		}
 
 	}

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -510,7 +510,7 @@ function Prune-InstalledVersions {
 
 	$AppWildCard = $ScriptDataFilenames.AppName+"*"
 
-	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Write-Output
+	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Write-Host
 
 	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Where-Object { $to_keep -notcontains $_.name } |`
 	Remove-Item -Recurse -whatif

--- a/src/install-matflow.ps1
+++ b/src/install-matflow.ps1
@@ -510,6 +510,8 @@ function Prune-InstalledVersions {
 
 	$AppWildCard = $ScriptDataFilenames.AppName+"*"
 
+	Get-Content $AppWildCard | Write-Output
+
 	Get-ChildItem $AppWildCard -Path $ScriptDataFilenames.Folder | Where-Object { $to_keep -notcontains $_.name } |`
 	Remove-Item -Recurse -whatif
 


### PR DESCRIPTION
Folder was included in saved path, Get-ChildItem was pointed to the folder so including folder in saved path not needed and meant files were removed unnecessarily. 