### PR TITLE
Bashrc multi install

### DIFF
--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -3,6 +3,8 @@ run_main() {
 
 	check_prerequisites
 
+	get_rc_file
+
 	set_variables
 
 	set_flags
@@ -412,45 +414,41 @@ keep_most_recent_stable () {
 
 }
 
+get_rc_file () {
+	# Store .bashrc or .zshrc in a variable
+	if [ -f ~/.zshrc ]; then
+		rc_file="~/.zshrc"
+	elif [ -f ~/.bashrc ]; then
+		rc_file="~/.bashrc"
+	fi
+}
+
 add_to_path () {
 
-	# Check which files exist
-	if [ -f ~/.zshrc ] && [[ "$onpath" = false ]]; then
-		echo "Updating ~/.zshrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.zshrc
+	# Update the (bash/zsh)rc file
+	if [ -f $rc_file ] && [[ "$onpath" = false ]]; then
+		echo "Updating $rc_file..."
+		echo "export PATH=\"\$PATH:"${folder}"/links\"" >> $rc_file
 	fi
-
-	if [ -f ~/.bashrc ] && [[ "$onpath" = false ]]; then
-		echo "Updating ~/.bashrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
-	fi
-
 }
 
 print_post_install_info () {
 
-	if [ -f ~/.zshrc ]; then
-		rcname="~/.zshrc"
-	fi
-
-	if [ -f ~/.bashrc ]; then
-		rcname="~/.bashrc"
-	fi
 
 	echo $completion_string_1
 	sleep 0.2
 	if [ "$path" != true ] && [ "$onpath" != true ]; then
 		echo
 		echo
-		echo "Add "${app_name}" to path by adding the following line to ${rcname}:"
+		echo "Add "${app_name}" to path by adding the following line to ${rc_file}:"
 		echo "export PATH=\"\$PATH:"${folder}"/links\""
 	fi
 	echo
 	echo
 	if [ "$univlink" == true ]; then
-		echo "Re-open terminal and type \"${univ_symstring}\" to get started, or type \"source ${rcname}\" followed by \"${univ_symstring}\" to start immediately." 
+		echo "Re-open terminal and type \"${univ_symstring}\" to get started, or type \"source ${rc_file}\" followed by \"${univ_symstring}\" to start immediately."
 	else
-		echo "Re-open terminal and type \"${versioned_symstring}\" to get started, or type \"source ${rcname}\" followed by \"${versioned_symstring}\" to start immediately." 
+		echo "Re-open terminal and type \"${versioned_symstring}\" to get started, or type \"source ${rc_file}\" followed by \"${versioned_symstring}\" to start immediately."
 	fi
 
 }

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -300,6 +300,10 @@ check_if_symlink_folder_on_path() {
 	*) ;;
 	esac
 
+	# or in rc_file
+	if grep -q "export PATH=\"\$PATH:"${folder}"/links\"" $rc_file; then
+		onpath=true
+	fi
 }
 
 download_artifact_to_temp() {

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -337,7 +337,7 @@ unzip_and_move_onefile_version() {
 create_versioned_symlink() {
 
 	if [ "$onefile" == true ]; then
-	
+
 		ln -sf "${folder}/${artifact_name}" "${folder}/links/${artifact_name}"
 		install_name=${artifact_name}
 		versioned_symstring="${artifact_name}"
@@ -371,7 +371,7 @@ create_universal_symlink() {
 				ln -sf "${folder}/${artifact_name}" "${folder}/links/${app_name}}"
 				univ_symstring="${app_name}"
 			fi
-		
+
 		else
 
 			if [ "$prerelease" == true ]; then

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -421,9 +421,9 @@ keep_most_recent_stable () {
 get_rc_file () {
 	# Store .bashrc or .zshrc in a variable
 	if [ -f ~/.zshrc ]; then
-		rc_file="~/.zshrc"
+		rc_file=~/.zshrc
 	elif [ -f ~/.bashrc ]; then
-		rc_file="~/.bashrc"
+		rc_file=~/.bashrc
 	fi
 }
 

--- a/src/install-hpcflow.sh
+++ b/src/install-hpcflow.sh
@@ -296,7 +296,7 @@ check_if_symlink_folder_on_path() {
 
 	# Check if folders on path already
 	case :$PATH: in
-	*:"${folder}"/links:) onpath=true ;;
+	*:"${folder}"/links:*) onpath=true ;;
 	*) ;;
 	esac
 

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -3,6 +3,8 @@ run_main() {
 
 	check_prerequisites
 
+	get_rc_file
+
 	set_variables
 
 	set_flags
@@ -294,10 +296,14 @@ check_if_symlink_folder_on_path() {
 
 	# Check if folders on path already
 	case :$PATH: in
-	*:"${folder}"/links:) onpath=true ;;
+	*:"${folder}"/links:*) onpath=true ;;
 	*) ;;
 	esac
 
+	# or in rc_file
+	if grep -q "export PATH=\"\$PATH:"${folder}"/links\"" $rc_file; then
+		onpath=true
+	fi
 }
 
 download_artifact_to_temp() {
@@ -412,45 +418,41 @@ keep_most_recent_stable () {
 
 }
 
+get_rc_file () {
+	# Store .bashrc or .zshrc in a variable
+	if [ -f ~/.zshrc ]; then
+		rc_file="~/.zshrc"
+	elif [ -f ~/.bashrc ]; then
+		rc_file="~/.bashrc"
+	fi
+}
+
 add_to_path () {
 
-	# Check which files exist
-	if [ -f ~/.zshrc ] && [[ "$onpath" = false ]]; then
-		echo "Updating ~/.zshrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.zshrc
+	# Update the (bash/zsh)rc file
+	if [ -f $rc_file ] && [[ "$onpath" = false ]]; then
+		echo "Updating $rc_file..."
+		echo "export PATH=\"\$PATH:"${folder}"/links\"" >> $rc_file
 	fi
-
-	if [ -f ~/.bashrc ] && [[ "$onpath" = false ]]; then
-		echo "Updating ~/.bashrc..."
-		echo "export PATH=\"\$PATH:"${folder}"/links\"" >>~/.bashrc
-	fi
-
 }
 
 print_post_install_info () {
 
-	if [ -f ~/.zshrc ]; then
-		rcname="~/.zshrc"
-	fi
-
-	if [ -f ~/.bashrc ]; then
-		rcname="~/.bashrc"
-	fi
 
 	echo $completion_string_1
 	sleep 0.2
 	if [ "$path" != true ] && [ "$onpath" != true ]; then
 		echo
 		echo
-		echo "Add "${app_name}" to path by adding the following line to ${rcname}:"
+		echo "Add "${app_name}" to path by adding the following line to ${rc_file}:"
 		echo "export PATH=\"\$PATH:"${folder}"/links\""
 	fi
 	echo
 	echo
 	if [ "$univlink" == true ]; then
-		echo "Re-open terminal and type \"${univ_symstring}\" to get started, or type \"source ${rcname}\" followed by \"${univ_symstring}\" to start immediately." 
+		echo "Re-open terminal and type \"${univ_symstring}\" to get started, or type \"source ${rc_file}\" followed by \"${univ_symstring}\" to start immediately."
 	else
-		echo "Re-open terminal and type \"${versioned_symstring}\" to get started, or type \"source ${rcname}\" followed by \"${versioned_symstring}\" to start immediately." 
+		echo "Re-open terminal and type \"${versioned_symstring}\" to get started, or type \"source ${rc_file}\" followed by \"${versioned_symstring}\" to start immediately."
 	fi
 
 }

--- a/src/install-matflow.sh
+++ b/src/install-matflow.sh
@@ -341,7 +341,7 @@ unzip_and_move_onefile_version() {
 create_versioned_symlink() {
 
 	if [ "$onefile" == true ]; then
-	
+
 		ln -sf "${folder}/${artifact_name}" "${folder}/links/${artifact_name}"
 		install_name=${artifact_name}
 		versioned_symstring="${artifact_name}"
@@ -375,7 +375,7 @@ create_universal_symlink() {
 				ln -sf "${folder}/${artifact_name}" "${folder}/links/${app_name}}"
 				univ_symstring="${app_name}"
 			fi
-		
+
 		else
 
 			if [ "$prerelease" == true ]; then
@@ -421,9 +421,9 @@ keep_most_recent_stable () {
 get_rc_file () {
 	# Store .bashrc or .zshrc in a variable
 	if [ -f ~/.zshrc ]; then
-		rc_file="~/.zshrc"
+		rc_file=~/.zshrc
 	elif [ -f ~/.bashrc ]; then
-		rc_file="~/.bashrc"
+		rc_file=~/.bashrc
 	fi
 }
 


### PR DESCRIPTION
Fix #59.

This works fine on my laptop, and the hpcflow installer works fine on CSF3, however, I get errors for installing matflow on CSF3. This might be because I already  have matflow installed there?
`$ ./install-matflow.sh --path --prerelease`
```
unzip:  cannot find or open /tmp/tmp.md1k5qKlQv/matflow-v0.3.0a110-linux-dir.zip, /tmp/tmp.md1k5qKlQv/matflow-v0.3.0a110-linux-dir.zip.zip or /tmp/tmp.md1k5qKlQv/matflow-v0.3.0a110-linux-dir.zip.ZIP.
chmod: cannot access ‘/tmp/tmp.md1k5qKlQv/dist/onedir/matflow-v0.3.0a110-linux-dir’: No such file or directory
mv: cannot stat ‘/tmp/tmp.md1k5qKlQv/dist/onedir/matflow-v0.3.0a110-linux-dir’: No such file or directory
find: ‘/mnt/iusers01/support/mbexegc2/.local/share/matflow/matflow-v*’: No such file or directory
```
If I delete the `~/.local/share/matflow` directory, it runs without error.
